### PR TITLE
Modificado el link del certificado

### DIFF
--- a/src/components/Education.astro
+++ b/src/components/Education.astro
@@ -7,7 +7,7 @@ const EDUCATION = [
     title: "Ingeniería en Informática",
     institution: "Universidad Andrés Bello",
     description: "Formación en bases de datos, programación y desarrollo de software.",
-    link: "https://universidad.com/certificado",
+    link: "https://certificados.unab.cl/qr.php?f=3438544&i=138471152",
   },
   {
     date: "2010",


### PR DESCRIPTION
Se incluye el link del certificado de título emanado desde código QR, se elimina link placeholder. 